### PR TITLE
Fix: Make it first target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+it: cs test
+
 composer:
 	composer validate
 	composer install
@@ -7,8 +9,6 @@ coverage: composer
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff
-
-it: cs test
 
 test: composer
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml


### PR DESCRIPTION
This PR

* [x] makes `it` the first target