### PR TITLE
Fix: Ignore php-cs-fixer cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/vendor/
-.idea
+.idea/
+vendor/
+.php_cs.cache


### PR DESCRIPTION
This PR

* [x] keeps entries in `.gitignore` sorted
* [x] ignores `php_cs.cache`