### PR TITLE
Fix: Pin refinery29/test-util to a concrete version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "fzaninotto/faker": "^1.5",
     "phpunit/phpunit": "^4.8",
     "refinery29/php-cs-fixer-config": "0.4.15",
-    "refinery29/test-util": "^0.2.0"
+    "refinery29/test-util": "0.4.3"
   },
   "license": "proprietary",
   "authors": [


### PR DESCRIPTION
This PR

* [x] pins `refinery29/test-util` to a concrete version

Follows https://github.com/refinery29/test-util/pull/54.