### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/test/Unit/Schema/SchemaBuilderTest.php
+++ b/test/Unit/Schema/SchemaBuilderTest.php
@@ -20,7 +20,7 @@ class SchemaBuilderTest extends \PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
 
-    public function setup()
+    protected function setUp()
     {
         AnnotationRegistry::registerAutoloadNamespace('Refinery29/SolrAnnotations/Annotation');
     }


### PR DESCRIPTION
This PR

* [x] reduces visibility of `setUp()` from `public` to `protected`

💁 This is the visibility as declared on the parent; there's no need to increase it.

