### PR TITLE
Enhancement: Keep packages sorted without specifying --sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
   ],
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "config": {
+    "sort-packages": true
+  },
   "require": {
     "php": "^5.5 || ^7.0",
     "beberlei/assert": "^2.5.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d46334864acbdc9529e12dc136b7ecc3",
+    "hash": "76b9237f4f72e2956cf928345ccad85f",
     "content-hash": "0cc65150d23d434eacf19022f95e940c",
     "packages": [
         {
@@ -494,6 +494,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": "guzzlehttp/guzzle",
             "time": "2014-01-28 22:29:15"
         },
         {


### PR DESCRIPTION
This PR

* [x] keeps packages sorted without having to specify the `--sort-packages` option