### PR TITLE
Parser reader must implement Reader interface

### DIFF
--- a/src/Annotation/Parser.php
+++ b/src/Annotation/Parser.php
@@ -11,6 +11,7 @@ namespace Refinery29\SolrAnnotations\Annotation;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\Reader;
 use Refinery29\SolrAnnotations\Annotation\Document as DocumentAnnotation;
 use ReflectionClass;
 
@@ -21,14 +22,14 @@ use ReflectionClass;
 class Parser
 {
     /**
-     * @var AnnotationReader
+     * @var Reader
      */
     private $reader;
 
     /**
-     * @param AnnotationReader $reader
+     * @param Reader $reader
      */
-    public function __construct(AnnotationReader $reader = null)
+    public function __construct(Reader $reader = null)
     {
         self::registerAnnotations();
         $this->reader = $reader ?: new AnnotationReader();

--- a/test/Unit/Annotation/ParserTest.php
+++ b/test/Unit/Annotation/ParserTest.php
@@ -9,6 +9,7 @@
 
 namespace Refinery29\SolrAnnotations\Test\Unit\Annotation;
 
+use Doctrine\Common\Annotations\Reader;
 use Refinery29\SolrAnnotations\Annotation\Parser;
 use Refinery29\SolrAnnotations\Test\Unit\Stub\AnnotatedClass;
 use Refinery29\SolrAnnotations\Test\Unit\Stub\NonAnnotatedClass;
@@ -36,5 +37,20 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $name = $parser->getDocumentName($refl);
 
         $this->assertSame($name, 'AnnotatedClassDocument');
+    }
+
+    public function testReaderCanAcceptReaderInterface()
+    {
+        $parser = new Parser($this->getReaderMock());
+
+        $this->assertInstanceOf(Parser::class, $parser);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Reader
+     */
+    private function getReaderMock()
+    {
+        return $this->getMock(Reader::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] `Parser#$reader` adheres to Doctrine `Reader` interface instead of `AnnotationReader` instantiation 
* [x] Test Coverage